### PR TITLE
Fixes chemouna/Nearby#1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,7 +117,7 @@ kapt {
   generateStubs = true
 }
 buildscript {
-  ext.kotlin_version = '1.0.0-rc-1036'
+  ext.kotlin_version = '1.0.0'
   repositories {
     mavenCentral()
   }

--- a/app/src/debug/kotlin/com/mounacheikhna/nearby/api/DebugApiModule.kt
+++ b/app/src/debug/kotlin/com/mounacheikhna/nearby/api/DebugApiModule.kt
@@ -3,12 +3,9 @@ package com.mounacheikhna.nearby.api
 import com.facebook.stetho.okhttp.StethoInterceptor
 import com.mounacheikhna.nearby.annotation.NetworkInterceptors
 import com.squareup.okhttp.Interceptor
-import com.squareup.okhttp.OkHttpClient
 import dagger.Module
 import dagger.Provides
 import org.threeten.bp.Clock
-import java.util.*
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -19,7 +16,7 @@ class DebugApiModule {
      * about server api to be logged on release buildS.
      */
     @Provides @Singleton @NetworkInterceptors
-    fun provideNetworkInterceptors(clock: Clock): List<Interceptor> {//dagger needs 'out' here
+    fun provideNetworkInterceptors(clock: Clock): List<@JvmWildcard Interceptor> {//dagger needs 'out' here
                                     // to generate the correct binding with '? extend' in java.
         return arrayListOf(StethoInterceptor(), LoggingInterceptor(clock))
     }

--- a/app/src/main/kotlin/com/mounacheikhna/nearby/api/CoreApiModule.kt
+++ b/app/src/main/kotlin/com/mounacheikhna/nearby/api/CoreApiModule.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 /**
  * Core dagger module that provides most core dependencies that the app needs.
  */
-@Module
+@Module()
 public class CoreApiModule {
 
     private val FOURSQUARE_ENDPOINT_URL = "https://api.foursquare.com/";
@@ -61,9 +61,7 @@ public class CoreApiModule {
 
     @Provides @Singleton @AppInterceptors
     fun provideAppInterceptors(
-        foursquareInterceptor: FoursquareInterceptor): List<Interceptor> {
-        return arrayListOf(foursquareInterceptor);
-    }
+        foursquareInterceptor: FoursquareInterceptor) : List<@JvmWildcard Interceptor> = arrayListOf(foursquareInterceptor)
 
     @Provides @Singleton
     fun provideRetrofit(@Named("Api") apiClient: OkHttpClient,

--- a/app/src/main/kotlin/com/mounacheikhna/nearby/ui/details/VenueDetailsView.kt
+++ b/app/src/main/kotlin/com/mounacheikhna/nearby/ui/details/VenueDetailsView.kt
@@ -85,7 +85,7 @@ public class VenueDetailsView : LinearLayout {
         FoursquareApp.appComponent.inject(this)
 
         activity.delegate.setSupportActionBar(toolbar)
-        supportActionBar = activity.supportActionBar
+        supportActionBar = activity.delegate.supportActionBar
         supportActionBar.setDisplayHomeAsUpEnabled(true);
         supportActionBar.setDisplayShowHomeEnabled(true);
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-  androidPlugin = 'com.android.tools.build:gradle:+'//2.0.0-beta2
+  androidPlugin = 'com.android.tools.build:gradle:2.0.0-beta5'//2.0.0-beta2
   minSdkVersion = 15
   minWearSdkVersion = 21
   targetSdkVersion = 23
@@ -9,12 +9,11 @@ ext {
   versionCode = 1
   versionName = "1.0"
 
-  //kotlinVersion = '1.0.0-rc-1036'
-  kotlinVersion = '1.0.0-beta-2423'
+  kotlinVersion = '1.0.0'
   kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   kotlinAndroidSdkAnnotations = "org.jetbrains.kotlin:kotlin-android-sdk-annotations:$kotlinVersion"
-  //kotlinAndroidExtensions = "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
+  kotlinAndroidExtensions = "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
 
   supportVersion = '23.1.1'
   supportAnnotations = "com.android.support:support-annotations:$supportVersion"


### PR DESCRIPTION
By default kotlin does not generate wildcards in return types. To do so you have to add @JvmWildcard annotation to return type or annotate function with @JvmSuppressWildcards(suppress = false).

Example:

``` kotlin
fun example(l: List<String>) // in Java: List<String> (String is final)
fun example(l: List<@JvmWildcard String>) // in Java: List<? extends String>

interface Foo {}
fun bar(p: List<Foo>) // in Java: List<Foo>
@JvmSuppressWildcards(suppress = false)
fun bar(p: List<Foo>) // in Java: List<? extends Foo>
```

Also I have changed kotlin version to newest one
